### PR TITLE
Fix title spelling.

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,7 +8,7 @@ const initKmtHeader = () => {
     data: {
       KmtHeaderNs: {
         headerTitle: {// custom header title
-          label: "Knowledge & Administration Tools",
+          label: "Knowledge & administration tools",
           summary: ""
         },
         mainMenu: {

--- a/src/reducers/header-title.js
+++ b/src/reducers/header-title.js
@@ -6,7 +6,7 @@ export const headerTitleTypes ={
 };
 
 const defaultState = {
-  label: "Knowledge & Administration Tools",
+  label: "Knowledge & administration tools",
   summary: ""
 };
 


### PR DESCRIPTION
Change from "Knowledge & Administration Tools" to "Knowledge & administration tools".