### PR TITLE
Final tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ pa11y_screenCapture
 
 *.env*
 
-.scss-lint.yml
+.stylelintrc
 
 dist
 

--- a/header.html
+++ b/header.html
@@ -33,19 +33,22 @@
 		<div class="o-header-services__container">
 			<ul class="o-header-services__nav-list">
 				{{#each nav.items}}
-				{{#if flag}}
-					{{#if (lookup @root.flags flag)}}
-						<li class="o-header-services__nav-item {{#if last}}o-header-services__nav-item--last kmt-text--transform-none{{/if}}">
-							<a class="o-header-services__nav-link {{#if selected}}o-header-services__nav-link--selected{{/if}}" href="{{href}}"
-							{{#if trackable}}data-trackable={{trackable}}{{/if}}>{{name}}</a>
-						</li>
+					{{#if showFlag}}
+						{{#if (lookup @root.flags showFlag)}}
+							<li class="o-header-services__nav-item {{#if last}}o-header-services__nav-item--last kmt-text--transform-none{{/if}}">
+								<a class="o-header-services__nav-link {{#if selected}}o-header-services__nav-link--selected{{/if}}" href="{{href}}"
+								{{#if trackable}}data-trackable={{trackable}}{{/if}}>{{name}}</a>
+							</li>
+						{{/if}}
+					{{else}}
+						{{#ifAll hideFlag (lookup @root.flags hideFlag)}}
+						{{else}}
+							<li class="o-header-services__nav-item {{#if last}}o-header-services__nav-item--last kmt-text--transform-none{{/if}}">
+								<a class="o-header-services__nav-link {{#if selected}}o-header-services__nav-link--selected{{/if}}" href="{{href}}"
+								{{#if trackable}}data-trackable={{trackable}}{{/if}}>{{name}}</a>
+							</li>
+						{{/ifAll}}
 					{{/if}}
-				{{else}}
-					<li class="o-header-services__nav-item {{#if last}}o-header-services__nav-item--last kmt-text--transform-none{{/if}}">
-						<a class="o-header-services__nav-link {{#if selected}}o-header-services__nav-link--selected{{/if}}" href="{{href}}"
-						{{#if trackable}}data-trackable={{trackable}}{{/if}}>{{name}}</a>
-					</li>
-				{{/if}}
 				{{/each}}
 			</ul>
 		</div>

--- a/main.scss
+++ b/main.scss
@@ -45,6 +45,10 @@ $o-forms-is-silent: false; // TODO: make this silent and only include mixins for
 	border-bottom: 0;
 }
 
+.o-header-services__nav-list {
+	display: inline-flex;
+}
+
 .o-header-services__nav-item--last {
 	float: right;
 

--- a/navigation-config.js
+++ b/navigation-config.js
@@ -20,24 +20,25 @@ module.exports = (licence, selectedTab) => {
 			name: 'Licence Administration',
 			href: `https://licence-admin.ft.com/licences/${licenceId}/users`,
 			trackable: 'licence-admin',
-		},
-		{
-			name: 'Groups',
-			href: `/groups/${licenceId}`,
-			trackable: 'groups',
-			flag: 'katGroupManagement'
+			hideFlag: 'katUsersManagement'
 		},
 		{
 			name: 'User Management',
 			href: `/users/${licenceId}`,
 			trackable: 'users',
-			flag: 'katUsersManagement'
+			showFlag: 'katUsersManagement'
+		},
+		{
+			name: 'Groups',
+			href: `/groups/${licenceId}`,
+			trackable: 'groups',
+			showFlag: 'katGroupManagement'
 		},
 		{
 			name: 'My Account',
 			href: 'https://myaccount.ft.com/',
 			trackable: 'my-account',
-			flag: 'katLicenceAdmin',
+			showFlag: 'katLicenceAdmin',
 			last: true
 		}
 	];

--- a/navigation-config.js
+++ b/navigation-config.js
@@ -28,7 +28,7 @@ module.exports = (licence, selectedTab) => {
 			flag: 'katGroupManagement'
 		},
 		{
-			name: 'Users',
+			name: 'User Management',
 			href: `/users/${licenceId}`,
 			trackable: 'users',
 			flag: 'katUsersManagement'


### PR DESCRIPTION
- [ ] Rename "Users" tab into "User Management" tab
- [ ] Implement logic that shows "User Management" tab when `katUsersManagement` flag is on, and "Licence Administration" otherwise
- [ ] Remove vertical line between menu items