### PR TITLE
fix licenceSwitch bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
 				const newLicenceSelection = event.target.value;
 				let newPath = currentPath.split('/');
 				newPath[2] = newLicenceSelection;
-				newPath = newPath.join('/');
+				newPath = newPath.slice(0, 3).join('/');
 
 				location.pathname = newPath;
 			});


### PR DESCRIPTION
from 
`/groups/:licenceId1/group-details/:groupId1`
switching the licence would go to
`/groups/:licenceId2/group-details/:groupId1`
But `groupId1` doesn't exist for the second licence making it 404. This fix ensures we only get the first part of the path to go back to each apps' "homepage"
  