### PR TITLE
bump to o-forms v5

### DIFF
--- a/.pa11yci.js
+++ b/.pa11yci.js
@@ -1,49 +1,43 @@
 const viewports = [
 	{
 		width: 768,
-		height: 1024
+		height: 1024,
 	},
 	{
 		width: 490,
-		height: 732
+		height: 732,
 	},
 	{
 		width: 320,
-		height: 480
-	}
+		height: 480,
+	},
 ];
 
-const urls = [
-	'http://localhost:5005/',
-	'http://localhost:5005/core'
-];
+const urls = ['http://localhost:5005/', 'http://localhost:5005/core'];
 
 const config = {
 	defaults: {
-		page: {
-			headers: {
-				'Cookie': 'next-flags=ads:off,cookieMessage:off; secure=true'
-			}
+		headers: {
+			Cookie: 'next-flags=ads:off,cookieMessage:off; secure=true',
 		},
 		timeout: 25000,
-		rules: ['Principle1.Guideline1_3.1_3_1_AAA']
+		rules: ['Principle1.Guideline1_3.1_3_1_AAA'],
 	},
-	urls: []
+	urls: [],
 };
 
 for (const viewport of viewports) {
 	for (const url of urls) {
-
-		const path = `${url.substring(url.lastIndexOf('/'))}@${viewport.width}x${viewport.height}`;
+		const path = `${url.substring(url.lastIndexOf('/'))}@${
+			viewport.width
+		}x${viewport.height}`;
 
 		config.urls.push({
 			url: url,
-			page: {
-				viewport: viewport
-			},
-			screenCapture: `./pa11y_screenCapture/${path}.png`
+			viewport,
+			screenCapture: `./pa11y_screenCapture/${path}.png`,
 		});
 	}
-};
+}
 
 module.exports = config;

--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
     "n-ui-foundations": "^2.5.0",
     "o-buttons": "^5.7.0",
     "o-header-services": "^2.0.1",
-    "o-colors": "^4.1.4"
+    "o-colors": "^4.1.4",
+    "o-forms": "^5.7.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "n-ui-foundations": "^2.5.0",
     "o-buttons": "^5.7.0",
-    "o-forms": "^4.0.3",
     "o-header-services": "^2.0.1",
     "o-colors": "^4.1.4"
   }

--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,12 @@
     "public"
   ],
   "dependencies": {
-    "n-ui-foundations": "^2.5.0",
     "o-buttons": "^5.7.0",
     "o-header-services": "^2.0.1",
     "o-colors": "^4.1.4",
     "o-forms": "^5.7.2"
+  },
+  "devDependencies": {
+    "n-ui-foundations": "^v3.0.0"
   }
 }

--- a/drawer.html
+++ b/drawer.html
@@ -14,13 +14,13 @@
 			<div class="header__drawer-form-container">
 				<div class="o-forms licence-switcher__form">
 					<form action="{{basePath}}licenceSwitch" method="POST" class="o-forms__affix-wrapper">
-						<label for="licenceSwitcherDrawer" class="n-util-visually-hidden o-normalise-visually-hidden">Licences</label>
+						<label for="licenceSwitcherDrawer" class="o-normalise-visually-hidden">Licences</label>
 						<select id="licenceSwitcherDrawer" name="licenceSelection" class="o-forms__select">
 							{{#each @root.licenceList}}
 							<option value="{{licenceId}}" {{#ifEquals licenceId @root.LICENCE_ID }}selected="true" {{/ifEquals}}>{{contractId}} - {{name}}</option>
 							{{/each}}
 						</select>
-						<div class="o-forms__suffix n-util-hide-js n-ui-hide-js">
+						<div class="o-forms__suffix n-ui-hide-js">
 							<button type="submit" class="licence-switcher__submit">Go To Licence</button>
 						</div>
 					</form>
@@ -38,7 +38,7 @@
 							<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{href}}"
 							{{#if trackable}}data-trackable={{trackable}}{{/if}}>
 							{{~ name ~}} {{#if selected}}
-							<span class="n-util-visually-hidden o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
+							<span class="o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
 						</li>
 					{{/if}}
 				{{else}}
@@ -48,7 +48,7 @@
 							<a class="o-header__drawer-menu-link o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{href}}"
 							{{#if trackable}}data-trackable={{trackable}}{{/if}}>
 							{{~ name ~}} {{#if selected}}
-							<span class="n-util-visually-hidden o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
+							<span class="o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
 						</li>
 					{{/ifAll}}
 				{{/if}}

--- a/header.html
+++ b/header.html
@@ -16,13 +16,13 @@
 			<span class="o-header-services__related-content-link">
 				<div class="o-forms licence-switcher__form">
 					<form action="{{basePath}}licenceSwitch" method="POST" class="o-forms__affix-wrapper">
-						<label for="licenceSwitcher" class="n-util-visually-hidden o-normalise-visually-hidden">Licences</label>
+						<label for="licenceSwitcher" class="o-normalise-visually-hidden">Licences</label>
 						<select id="licenceSwitcher" name="licenceSelection" class="o-forms__select">
 							{{#each @root.licenceList}}
 							<option value="{{licenceId}}" {{#ifEquals licenceId @root.LICENCE_ID }}selected="true"{{/ifEquals}}>{{contractId}} - {{name}}</option>
 							{{/each}}
 						</select>
-						<div class="o-forms__suffix n-util-hide-js n-ui-hide-js">
+						<div class="o-forms__suffix n-ui-hide-js">
 							<button type="submit" class="licence-switcher__submit o-buttons o-buttons--big">Go To Licence</button>
 						</div>
 					</form>
@@ -41,7 +41,7 @@
 								<a class="o-header-services__nav-link {{#if selected}}o-header-services__nav-link--selected{{/if}}" href="{{href}}"
 								{{#if trackable}}data-trackable={{trackable}}{{/if}}>
 								{{~ name ~}}
-								{{#if selected}}<span class="n-util-visually-hidden o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
+								{{#if selected}}<span class="o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
 							</li>
 						{{/if}}
 					{{else}}
@@ -51,7 +51,7 @@
 							<a class="o-header-services__nav-link {{#if selected}}o-header-services__nav-link--selected{{/if}}" href="{{href}}"
 							{{#if trackable}}data-trackable={{trackable}}{{/if}}>
 							{{~ name ~}}
-							{{#if selected}}<span class="n-util-visually-hidden o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
+							{{#if selected}}<span class="o-normalise-visually-hidden"> Current page.</span>{{/if}}</a>
 						</li>
 						{{/ifAll}}
 					{{/if}}

--- a/header.html
+++ b/header.html
@@ -23,7 +23,7 @@
 							{{/each}}
 						</select>
 						<div class="o-forms__suffix n-util-hide-js n-ui-hide-js">
-							<button type="submit" class="licence-switcher__submit">Go To Licence</button>
+							<button type="submit" class="licence-switcher__submit o-buttons o-buttons--big">Go To Licence</button>
 						</div>
 					</form>
 				</div>

--- a/main.scss
+++ b/main.scss
@@ -19,8 +19,7 @@ $o-forms-is-silent: false;
 }
 
 .licence-switcher__submit {
-	@include oButtons();
-	color: oColorsGetPaletteColor('claret');
+	@include oButtons(big, primary);
 }
 
 .header__drawer-form-container {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "nodemon": "^1.12.1",
     "npm-prepublish": "^1.2.3",
     "origami-build-tools": "^6.2.5",
-    "pa11y-ci": "^1.3.0",
+    "pa11y-ci": "^2.1.1",
     "sass-lint": "^1.12.1"
   },
   "scripts": {


### PR DESCRIPTION
Slightly changes the core experience’s look. This should probably be released as a major version so that each app can bump their o-forms and this simultaneously to avoid odd form styling.

### Before
<img width="275" alt="screenshot 2018-06-19 12 15 20" src="https://user-images.githubusercontent.com/11544418/41658804-779f49d4-748f-11e8-8614-5a8f6fb4c765.png">

### After
<img width="280" alt="screenshot 2018-06-19 12 15 14" src="https://user-images.githubusercontent.com/11544418/41658809-7c6e9f50-748f-11e8-894d-fb9c6d1c3da9.png">



 🐿 v2.8.0