### PR TITLE
Bump o-forms to 6.0.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "o-buttons": "^5.7.0",
     "o-header-services": "^2.0.1",
     "o-colors": "^4.1.4",
-    "o-forms": "^5.7.2"
+    "o-forms": "^6.0.2"
   },
   "devDependencies": {
     "n-ui-foundations": "^v3.0.0"


### PR DESCRIPTION
This allows kmt-header dependencies to upgrade to the new o-loading.  Problem uncovered whilst using `kat-overview`.
